### PR TITLE
Quick fix for using 'uri' instead of 'path'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 pkg
 Gemfile.lock
+*.iml
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,99 +1,55 @@
-[![Puppet Forge](http://img.shields.io/puppetforge/v/lynxman/hiera_consul.svg)](https://forge.puppetlabs.com/lynxman/hiera_consul)
+
+Based on [lynxman/hiera_consul](https://github.com/lynxman/hiera-consul) and fork by [iwagnerclgx](https://github.com/iwagnerclgx/hiera-consul)
 
 [consul](http://www.consul.io) is an orchestration mechanism with fault-tolerance based on the gossip protocol and a key/value store that is strongly consistent. Hiera-consul will allow hiera to write to the k/v store for metadata centralisation and harmonisation.
 
 ## Installation
 
-For usage with puppet, install the module in your local environment, e.g.:
+Clone and build:
 
-    puppet module install lynxman/hiera_consul
-    
-or using a Puppetfile:
+    puppet module build
+    puppet module install /path/to/module.tar.gz
 
-    mod 'lynxman/hiera_consul'
-
-Ensure the backend `consul_backend.rb` is available into your hiera environment. Depending on your hiera/puppet environment, you may need to install the backend manually (or with puppet) at the correct path, which may be puppets local ruby path, e.g. `$PUPPET_DIR/lib/ruby/vendor_ruby/hiera/backend/consul_backend.rb`
-
-Puppet loads backends differently in some version, see [#SERVER-571](https://tickets.puppetlabs.com/si/jira.issueviews:issue-html/SERVER-571/SERVER-571.html) for more information.
+Ensure the function `consul_lookup_key` is available in your Puppet environment; on my box this is `$PUPPET_DIR/lib/ruby/vendor_ruby/puppet/functions`
 
 ## Configuration
 
-The following hiera.yaml should get you started:
+This is my `hiera.yaml`, YMMV
 
-    :backends:
-      - consul
-
-    :consul:
-      :host: 127.0.0.1
-      :port: 8500
-      :paths:
-        - /v1/kv/configuration/%{fqdn}
-        - /v1/kv/configuration/common
-
-The array `:paths:` allows hiera to access the namespaces in it. As an example, you can query `/v1/kv/configuration/common/yourkey` using 
-
-    hiera('yourkey', [])
+    version: 5
     
-This will return a consul array, which can further processed. See the helper function `consul_info` below for more information.
+    hierarchy:
+      - name: Consul
+        lookup_key: consul_lookup_key
+        uris:
+          - "/v1/kv/puppet/nodes/%{trusted.certname}"
+          - "/v1/kv/puppet/environments/%{::environment}"
+          - "/v1/kv/puppet/common"
+        options:
+          host: localhost
+          port: 8500
+          use_ssl: false
+          ignore_404: true
 
-## Extra parameters
+## Parameters
 
-As this module uses http to talk with Consul API the following parameters are also valid and available
+A list of all parameters with examples is below
 
-    :consul:
-      :host: 127.0.0.1
-      :port: 8500
-      :use_ssl: false
-      :ssl_verify: false
-      :ssl_cert: /path/to/cert
-      :ssl_key: /path/to/key
-      :ssl_ca_cert: /path/to/ca/cert
-      :failure: graceful
-      :ignore_404: true
-      :token: acl-uuid-token
+      host: 127.0.0.1
+      port: 8500
+      use_ssl: false
+      ssl_verify: false
+      ssl_cert: /path/to/cert
+      ssl_key: /path/to/key
+      ssl_ca_cert: /path/to/ca/cert
+      failure: graceful
+      ignore_404: true
+      token: acl-uuid-token
 
-## Query the catalog
+## Notes
 
-You can also query the Consul catalog for values by adding catalog resources in your paths, the values will be returned as an array so you will need to parse accordingly.
+The upstream packages included a host of other functions, I haven't gone through and tested these myself (yet). Please see README from [upstream](https://github.com/lynxman/hiera-consul)
 
-    :backends:
-      - consul
+## CREDITS
 
-    :consul:
-      :host: 127.0.0.1
-      :port: 8500
-      :paths:
-        - /v1/kv/configuration/%{fqdn}
-        - /v1/kv/configuration/common
-        - /v1/catalog/service
-        - /v1/catalog/node
-
-## Helper function
-
-### consul_info
-
-This function will allow you to read information out of a consul Array returned by hiera, as an example here we recover node IPs based on a service:
-
-    $consul_service_array = hiera('rabbitmq',[])
-    $mq_cluster_nodes = consul_info($consul_service_array, 'Address')
-
-In this example `$mq_cluster_nodes` will have an array with all the IP addresses related to that service
-
-You can also call it more with than one field and a separator and it will generate a composed string for each element in the consul query result.
-
-    $consul_service_array = hiera('rabbitmq',[])
-    $mq_cluster_nodes = consul_info($consul_service_array, [ 'Address', 'Port' ], ':')
-
-The result will return an array like this: [ AddressA:PortA, AddressB:PortB ]
-
-If you want to flatten the output array you can always use [join](https://forge.puppetlabs.com/puppetlabs/stdlib) from the Puppet stdlib.
-
-    $myresult = join($mq_cluster_nodes, ",")
-
-## Thanks
-
-Heavily based on [etcd-hiera](https://github.com/garethr/hiera-etcd) written by @garethr which was inspired by [hiera-http](https://github.com/crayfishx/hiera-http) from @crayfishx.
-
-Thanks to @mitchellh for writing such wonderful tools and the [API Documentation](http://www.consul.io/docs/agent/http.html)
-
-Thanks for their contributions to [Wei Tie](https://github.com/TieWei), [Derek Tracy](https://github.com/tracyde), [Michael Chapman](https://github.com/michaeltchapman), [Kyle O'Donnell](https://github.com/kyleodonnell), [AJ](https://github.com/aj-jester) and [lcrisci](https://github.com/lcrisci)
+Please see README from [upstream](https://github.com/lynxman/hiera-consul)

--- a/lib/puppet/functions/consul_data_hash.rb
+++ b/lib/puppet/functions/consul_data_hash.rb
@@ -1,0 +1,136 @@
+Puppet::Functions.create_function(:consul_data_hash) do
+  require 'net/http'
+  require 'net/https'
+  require 'json'
+  require 'yaml'
+
+  dispatch :consul_data_hash do
+    param 'Hash', :options
+    param 'Puppet::LookupContext', :context
+  end
+
+  def consul_init(options, context)
+    @options = options
+    @context = context
+
+    unless @options.include?('host')
+      raise ArgumentError, "'consul_data_hash': 'host' must be declared in Puppet.yaml when using this data_hash function"
+    end
+
+    unless @options.include?('port')
+      raise ArgumentError, "'consul_data_hash': 'port' must be declared in Puppet.yaml when using this data_hash function"
+    end
+
+    unless @options.include?('consul_kv_path')
+      raise ArgumentError, "'consul_data_hash': 'consul_kv_path' must be declared in Puppet.yaml when using this data_hash function"
+    end
+
+    unless @options.include?('data_format') && %w[json yaml].include?(@options['data_format'])
+      raise ArgumentError, "'consul_data_hash': 'data_format' must be declared as type json or yaml"
+    end
+
+    if @options['consul_kv_path'] !~ /^\/v\d\/(kv)\//
+      Puppet.warning("[hiera-consul]: We only support queries to kv and you asked #{consul_kv_path}, skipping")
+    end
+
+    @consul_kv_path = @options['consul_kv_path']
+    @consul_data_format = @options['data_format']
+    @graceful_failure = @options.include?('graceful_failure') ? @options['graceful_failure'] : false
+
+    @consul = Net::HTTP.new(@options['host'], @options['port'])
+    @consul.read_timeout = @options['http_read_timeout'] || 10
+    @consul.open_timeout = @options['http_connect_timeout'] || 10
+
+    if @options['use_ssl']
+      @consul.use_ssl = true
+
+      @consul.verify_mode = if @options['ssl_verify'] == false
+                              OpenSSL::SSL::VERIFY_NONE
+                            else
+                              OpenSSL::SSL::VERIFY_PEER
+                            end
+
+      if @options['ssl_cert']
+        store = OpenSSL::X509::Store.new
+        store.add_cert(OpenSSL::X509::Certificate.new(File.read(@options['ssl_ca_cert'])))
+        @consul.cert_store = store
+
+        @consul.key = OpenSSL::PKey::RSA.new(File.read(options['ssl_cert']))
+        @consul.cert = OpenSSL::X509::Certificate.new(File.read(@options['ssl_cert']))
+      end
+    else
+      @consul.use_ssl = false
+    end
+  end
+
+  def consul_data_hash(options, context)
+
+    # Init a consul handler, and do some sanity checks
+    consul_init(options, context)
+    answer_hash = nil
+
+    answer_text = wrapquery()
+    unless not answer_text
+      answer_hash = parse_data(answer_text)
+      context.cache_all(answer_hash) if answer_hash
+    end
+
+    unless not answer_hash
+      context.cache_all(answer_hash)
+      return answer_hash
+    end
+
+    answer_hash
+
+  end
+
+  def parse_data(data)
+    answer_hash = nil
+    if @consul_data_format == 'json'
+      begin
+        answer_hash = JSON.parse(answer_text)
+      rescue JSON::ParserError
+        Puppet.warning("[hiera-consul]: JSON Parse Error for path #{@consul_kv_path}")
+        raise Exception, e.message unless @graceful_failure
+      end
+    elsif @consul_data_format == 'yaml'
+      begin
+        answer_hash = YAML.load(answer_text)
+      rescue YAML::SyntaxError => e
+        Puppet.warning("[hiera-consul]: YAML Parse Error for path #{@consul_kv_path}")
+        raise Exception, e.message unless @graceful_failure
+      end
+    end
+
+    answer_hash
+  end
+
+
+  private
+
+  def token(path)
+    # Token is passed only when querying kv store
+    "&token=#{@options['token']}" if @options['token'] && path =~ /^\/v\d\/kv\//
+  end
+
+  def wrapquery()
+    # Get a raw response, so we don't have to parse
+    req_path = "#{@consul_kv_path}?raw"
+    httpreq = Net::HTTP::Get.new("#{req_path}#{token(req_path)}")
+    answer = nil
+    begin
+      result = @consul.request(httpreq)
+    rescue Exception => e
+      Puppet.warning('[hiera-consul]: Could not connect to Consul')
+      raise Exception, e.message unless @graceful_failure
+      return answer
+    end
+    unless result.is_a?(Net::HTTPSuccess)
+      Puppet.warning("[hiera-consul]: HTTP response code was #{result.code}")
+      return answer
+    end
+    Puppet.warning("[hiera-consul]: Answer was #{result.body}")
+    answer = result.body
+    answer
+  end
+end

--- a/lib/puppet/functions/consul_data_hash.rb
+++ b/lib/puppet/functions/consul_data_hash.rb
@@ -30,7 +30,7 @@ Puppet::Functions.create_function(:consul_data_hash) do
     end
 
     if @options['consul_kv_path'] !~ /^\/v\d\/(kv)\//
-      Puppet.warning("[hiera-consul]: We only support queries to kv and you asked #{consul_kv_path}, skipping")
+      raise ArgumentError, "[hiera-consul]: We only support queries to kv and you asked #{consul_kv_path}"
     end
 
     @consul_kv_path = @options['consul_kv_path']
@@ -126,10 +126,10 @@ Puppet::Functions.create_function(:consul_data_hash) do
       return answer
     end
     unless result.is_a?(Net::HTTPSuccess)
-      Puppet.warning("[hiera-consul]: HTTP response code was #{result.code}")
+      Puppet.debug("[hiera-consul]: HTTP response code was #{result.code}")
       return answer
     end
-    Puppet.warning("[hiera-consul]: Answer was #{result.body}")
+    Puppet.debug("[hiera-consul]: Answer was #{result.body}")
     answer = result.body
     answer
   end

--- a/lib/puppet/functions/consul_data_hash.rb
+++ b/lib/puppet/functions/consul_data_hash.rb
@@ -84,7 +84,7 @@ Puppet::Functions.create_function(:consul_data_hash) do
 
   end
 
-  def parse_data(data)
+  def parse_data(answer_text)
     answer_hash = nil
     if @consul_data_format == 'json'
       begin

--- a/lib/puppet/functions/consul_lookup_key.rb
+++ b/lib/puppet/functions/consul_lookup_key.rb
@@ -12,14 +12,6 @@ Puppet::Functions.create_function(:consul_lookup_key) do
 
   def consul_init (options)
 
-    unless options.include?('host')
-      raise ArgumentError, "'consul_lookup_key': 'host' must be declared in Puppet.yaml when using this lookup_key function"
-    end
-
-    unless options.include?('port')
-      raise ArgumentError, "'consul_lookup_key': 'port' must be declared in Puppet.yaml when using this lookup_key function"
-    end
-
     @options = options
     unless @options.include?('host')
       raise ArgumentError, "'consul_lookup_key': 'host' must be declared in Puppet.yaml when using this lookup_key function"

--- a/lib/puppet/functions/consul_lookup_key.rb
+++ b/lib/puppet/functions/consul_lookup_key.rb
@@ -1,0 +1,149 @@
+Puppet::Functions.create_function(:consul_lookup_key) do
+  require 'net/http'
+  require 'net/https'
+  require 'json'
+
+
+  dispatch :consul_lookup_key do
+    param 'Variant[String, Numeric]', :key
+    param 'Hash', :options
+    param 'Puppet::LookupContext', :context
+  end
+
+  def consul_init (options)
+
+    unless options.include?('host')
+      raise ArgumentError, "'consul_lookup_key': 'host' must be declared in Puppet.yaml when using this lookup_key function"
+    end
+
+    unless options.include?('port')
+      raise ArgumentError, "'consul_lookup_key': 'port' must be declared in Puppet.yaml when using this lookup_key function"
+    end
+
+    @options = options
+    unless @options.include?('host')
+      raise ArgumentError, "'consul_lookup_key': 'host' must be declared in Puppet.yaml when using this lookup_key function"
+    end
+
+    unless @options.include?('port')
+      raise ArgumentError, "'consul_lookup_key': 'port' must be declared in Puppet.yaml when using this lookup_key function"
+    end
+
+    @consul = Net::HTTP.new(@options['host'], @options['port'])
+
+    @consul.read_timeout = @options['http_read_timeout'] || 10
+    @consul.open_timeout = @options['http_connect_timeout'] || 10
+
+    if @options['use_ssl']
+      @consul.use_ssl = true
+
+      if @options['ssl_verify'] == false
+        @consul.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      else
+        @consul.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      end
+
+      if @options['ssl_cert']
+        store = OpenSSL::X509::Store.new
+        store.add_cert(OpenSSL::X509::Certificate.new(File.read(@options['ssl_ca_cert'])))
+        @consul.cert_store = store
+
+        @consul.key = OpenSSL::PKey::RSA.new(File.read(options['ssl_cert']))
+        @consul.cert = OpenSSL::X509::Certificate.new(File.read(@options['ssl_cert']))
+      end
+    else
+      @consul.use_ssl = false
+    end
+
+  end
+
+
+  def consul_lookup_key(key, options, context)
+
+    return context.cached_value(key) if context.cache_has_key(key)
+
+    consul_init(options)
+    answer = nil
+
+    options['paths'].each do |path|
+
+      Puppet.debug("[hiera-consul]: Lookup Path/key: #{path} #{key}")
+
+      if path.start_with?('::consul_node::')
+        return path
+      end
+
+
+      Puppet.debug("[hiera-consul]: Lookup #{path}/#{key} on #{options['host']}:#{options['port']}")
+      # Check that we are not looking somewhere that will make hiera crash subsequent lookups
+      if "#{path}/#{key}".match('//')
+        Puppet.debug("[hiera-consul]: The specified path #{path}/#{key} is malformed, skipping")
+        next
+      end
+      # We only support querying the catalog or the kv store
+      if path !~ /^\/v\d\/(catalog|kv)\//
+        Puppet.debug("[hiera-consul]: We only support queries to catalog and kv and you asked #{path}, skipping")
+        next
+      end
+      answer = wrapquery("#{path}/#{key}", options)
+      next unless answer
+      break
+    end
+
+    return context.not_found() if not answer
+    context.cache(key, answer)
+  end
+
+  def parse_result(res)
+    require 'base64'
+    answer = nil
+    if res == 'null'
+      Puppet.debug('[hiera-consul]: Jumped as consul null is not valid')
+      return answer
+    end
+    # Consul always returns an array
+    res_array = JSON.parse(res)
+    # See if we are a k/v return or a catalog return
+    if !res_array.empty?
+      if res_array.first.include? 'Value'
+        if res_array.first['Value'].nil?
+          # The Value is nil so we return it directly without trying to decode it ( which would fail )
+          return answer
+        else
+          answer = Base64.decode64(res_array.first['Value'])
+        end
+      else
+        answer = res_array
+      end
+    else
+      Puppet.debug('[hiera-consul]: Jumped as array empty')
+    end
+    answer
+  end
+
+  private
+
+  def token(path, options)
+    # Token is passed only when querying kv store
+    "?token=#{options['token']}" if options['token'] && path =~ /^\/v\d\/kv\//
+  end
+
+  def wrapquery(path, options)
+    httpreq = Net::HTTP::Get.new("#{path}#{token(path, options)}")
+    answer = nil
+    begin
+      result = @consul.request(httpreq)
+    rescue Exception => e
+      Puppet.warning('[hiera-consul]: Could not connect to Consul')
+      raise Exception, e.message unless options['failure'] == 'graceful'
+      return answer
+    end
+    unless result.is_a?(Net::HTTPSuccess)
+      Puppet.debug("[hiera-consul]: HTTP response code was #{result.code}")
+      return answer
+    end
+    Puppet.debug("[hiera-consul]: Answer was #{result.body}")
+    answer = parse_result(result.body)
+    answer
+  end
+end

--- a/metadata.json
+++ b/metadata.json
@@ -1,13 +1,13 @@
 {
   "name": "lynxman-hiera_consul",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Marc Cluet",
   "license": "Apache-2.0",
   "summary": "Module for using consul as a hiera backend",
   "description": "Use consul by Hashicorp, as a hiera backend",
-  "source": "https://github.com/lynxman/hiera-consul.git",
-  "project_page": "https://forge.puppetlabs.com/lynxman/hiera_consul",
-  "issues_url": "https://github.com/lynxman/hiera-consul/issues",
+  "source": "https://github.com/rmacd/hiera-consul.git",
+  "project_page": "https://forge.puppetlabs.com/rmacd/hiera_consul",
+  "issues_url": "https://github.com/rmacd/hiera-consul/issues",
   "tags": ["consul", "hiera"],
   "operatingsystem_support": [
     {

--- a/metadata.json
+++ b/metadata.json
@@ -1,13 +1,12 @@
 {
-  "name": "lynxman-hiera_consul",
-  "version": "0.1.3",
-  "author": "Marc Cluet",
+  "name": "hiera_consul",
+  "version": "2.0.0",
   "license": "Apache-2.0",
-  "summary": "Module for using consul as a hiera backend",
-  "description": "Use consul by Hashicorp, as a hiera backend",
+  "summary": "Module for using Consul as a hiera backend",
+  "description": "Use Consul by Hashicorp, as a Hiera 5 backend",
   "source": "https://github.com/rmacd/hiera-consul.git",
-  "project_page": "https://forge.puppetlabs.com/rmacd/hiera_consul",
   "issues_url": "https://github.com/rmacd/hiera-consul/issues",
+  "upstream": "https://github.com/lynxman/hiera-consul",
   "tags": ["consul", "hiera"],
   "operatingsystem_support": [
     {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "hiera_consul",
-  "version": "2.0.0",
+  "version": "2.0.0-devel",
   "license": "Apache-2.0",
   "summary": "Module for using Consul as a hiera backend",
   "description": "Use Consul by Hashicorp, as a Hiera 5 backend",


### PR DESCRIPTION
Main changes - 
* changed the key lookup so that it's grabbing the 'urls' hash from the config rather than 'paths' (paths no longer work because Puppet 5.6.x checks to see that the path exists on the filesystem)
* updated the README with more up-to-date examples (work in progress, have been unable to test the hashing functionality so have removed that from README for now)
